### PR TITLE
Separate CI and Release action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
   pull_request:
 
 jobs:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,8 +5,29 @@ on:
     branches: [main]
 
 jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Run pre-commit
+        uses: ./pre-commit
+      - name: commitlint
+        uses: ./commitlint
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Run tests
+        run: echo "Running tests"
+
   release:
     name: Release
+    needs: [lint, test]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
By mutualizing Lint and Test, we create issues in release. Separating the actions between CI and Release should help with this (at the cost of duplicating the code for these actions)